### PR TITLE
fix: traveloka paylater recommendation header

### DIFF
--- a/public/scss/pages/PaymentMethod.module.scss
+++ b/public/scss/pages/PaymentMethod.module.scss
@@ -525,7 +525,7 @@
     &__header
     {
       @include typographyBuilder(secondary, 400, 10, 16);
-      @include fixedWidth(100%);
+      width: 100%;
       padding: 5px 0;
       text-align: center;
       align-items: center;


### PR DESCRIPTION
Sebelumnya kalau pakai `fixedWidth(100%)`
<img width="165" alt="image" src="https://user-images.githubusercontent.com/45808774/171113876-6cacc45e-1777-46a5-80d0-df4afed5e1c8.png">

Hasil setelah pakai `width: 100%`
<img width="288" alt="image" src="https://user-images.githubusercontent.com/45808774/171114329-fd91aa89-3930-4745-b810-be3e4ca1c94d.png">
