### PR TITLE
Chore/bump nexus 2.7.7

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -500,6 +500,7 @@
     "share": "Share Product",
     "shareProduct": "Share Product",
     "sort": "Sort",
+    "stockAvailable": "Stocks Available",
     "successAddToCart": "Successfuly add to cart!",
     "summary": "Summary",
     "timeout": "Time Out",

--- a/locales/en.json
+++ b/locales/en.json
@@ -135,7 +135,8 @@
     "writeNoteToSeller": "Note To Seller"
   },
   "categories": {
-    "categories": "Categories"
+    "categories": "Categories",
+    "title": "All Categories"
   },
   "contact": {
     "formIsEmpty": "Form is empty",

--- a/locales/en.json
+++ b/locales/en.json
@@ -609,7 +609,8 @@
   "settingNotification": {
     "title": "Notification",
     "description": "You will get all notification from this store according to the medium you activated below",
-    "emailDescription": "All notification by email cannot changed"
+    "emailDescription": "All notification by email cannot changed",
+    "pleaseFillWANumber": "Please fill your whatsapp number first"
   },
   "shipping": {
     "allocating": "Looking for a driver",

--- a/locales/en.json
+++ b/locales/en.json
@@ -612,7 +612,7 @@
     "title": "Notification",
     "description": "You will get all notification from this store according to the medium you activated below",
     "emailDescription": "All notification by email cannot changed",
-    "pleaseFillWANumber": "Please fill your whatsapp number first"
+    "pleaseFillWANumber": "Please fill your Whatsapp number first"
   },
   "shipping": {
     "allocating": "Looking for a driver",

--- a/locales/id.json
+++ b/locales/id.json
@@ -610,7 +610,8 @@
   "settingNotification": {
     "description": "Anda akan mendapatkan semua notifikasi dari toko ini sesuai dengan media yang Anda aktifkan di bawah ini",
     "emailDescription": "Semua notifikasi melalui email tidak dapat diubah",
-    "title": "Notifikasi"
+    "title": "Notifikasi",
+    "pleaseFillWANumber": "Mohon untuk mengisi nomor whatsapp terlebih dahulu"
   },
   "shipping": {
     "allocating": "Sedang mencari kurir",

--- a/locales/id.json
+++ b/locales/id.json
@@ -613,7 +613,7 @@
     "description": "Anda akan mendapatkan semua notifikasi dari toko ini sesuai dengan media yang Anda aktifkan di bawah ini",
     "emailDescription": "Semua notifikasi melalui email tidak dapat diubah",
     "title": "Notifikasi",
-    "pleaseFillWANumber": "Mohon untuk mengisi nomor whatsapp terlebih dahulu"
+    "pleaseFillWANumber": "Mohon untuk mengisi nomor Whatsapp terlebih dahulu"
   },
   "shipping": {
     "allocating": "Sedang mencari kurir",

--- a/locales/id.json
+++ b/locales/id.json
@@ -135,7 +135,8 @@
     "writeNoteToSeller": "Catatan untuk penjual"
   },
   "categories": {
-    "categories": "Kategori"
+    "categories": "Kategori",
+    "title": "Semua Kategori"
   },
   "contact": {
     "formIsEmpty": "Formulir belum diisi",

--- a/locales/id.json
+++ b/locales/id.json
@@ -500,6 +500,7 @@
     "share": "Bagikan Produk",
     "shareProduct": "Bagikan Produk",
     "sort": "Urutkan",
+    "stockAvailable": "Stok Tersedia",
     "successAddToCart": "Sukses masuk keranjang!",
     "summary": "Ringkasan",
     "timeout": "Waktu Habis",

--- a/pages/[lng]/categories/index.tsx
+++ b/pages/[lng]/categories/index.tsx
@@ -88,7 +88,7 @@ const CategoriesPage: FC<any> = ({
               productCategoryType="INFINITE_SCROLL"
               itemPerPage={pageInfo.itemPerPage}
               classes={classesProductCategory}
-              itemProductsPerCategory={3}
+              itemProductsPerCategory={6}
               getPageInfo={setPageInfo as any}
               thumborSetting={{
                 width: size.width < 768 ? 512 : 800,

--- a/pages/[lng]/categories/index.tsx
+++ b/pages/[lng]/categories/index.tsx
@@ -1,0 +1,151 @@
+/* library package */
+import { FC, useState } from 'react'
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { useRouter } from 'next/router'
+import { RiQuestionFill } from 'react-icons/ri'
+import { ProductListByCategory, useI18n } from '@sirclo/nexus'
+/* library template */
+import { useBrand } from 'lib/useBrand'
+import useInfiniteScroll from 'lib/useInfiniteScroll'
+import useWindowSize from 'lib/useWindowSize'
+/* components */
+import SEO from 'components/SEO'
+import Layout from 'components/Layout/Layout'
+import Breadcrumb from 'components/Breadcrumb/Breadcrumb'
+import EmptyComponent from 'components/EmptyComponent/EmptyComponent'
+/* styles */
+import styles from 'public/scss/pages/Categories.module.scss'
+import styleProducts from 'public/scss/pages/Products.module.scss'
+import styleButton from 'public/scss/components/Button.module.scss'
+import styleProduct from 'public/scss/components/Product.module.scss'
+import Loader from 'components/Loader/Loader'
+
+const classesProductCategory = {
+  productContainerClassName: `col-6 product_list ${styles.productsItemContainer}`,
+  stickerContainerClassName: `${styleProduct.product_sticker} ${styleProduct.product_stickerGrid}`,
+  outOfStockLabelClassName: `${styleProduct.product_stickerLabel} ${styleProduct.product_stickerLabel__outofstock}`,
+  saleLabelClassName: `${styleProduct.product_stickerLabel} ${styleProduct.product_stickerLabel__sale}`,
+  comingSoonLabelClassName: `${styleProduct.product_stickerLabel} ${styleProduct.product_stickerLabel__comingsoon}`,
+  openOrderLabelClassName: `${styleProduct.product_stickerLabel} ${styleProduct.product_stickerLabel__openorder}`,
+  preOrderLabelClassName: `${styleProduct.product_stickerLabel} ${styleProduct.product_stickerLabel__preorder}`,
+  newLabelClassName: `${styleProduct.product_stickerLabel} ${styleProduct.product_stickerLabel__new}`,
+  productImageContainerClassName: styleProduct.product_link,
+  productImageClassName: styleProduct.product_itemContainerImage,
+  productLabelContainerClassName: styleProduct.product_label,
+  productTitleClassName: styleProduct.product_label__title,
+  productPriceClassName: styleProduct.product_labelPrice,
+  salePriceClassName: styleProduct.product_labelPrice__sale,
+  priceClassName: styleProduct.product_labelPrice__price,
+  productsListCategoryHeaderTitleClassName: styles.productsListCategoryHeaderTitle,
+  productsListCategoryHeaderClassName: styles.productsListCategoryHeader,
+  productsListCategoryContainerClassName: styles.productsListCategoryContainer,
+  productsListCategoryHeaderLinkClassName: styles.productsListCategoryHeaderLink,
+  productsListContainerClassName: styles.productsListContainer,
+}
+
+const CategoriesPage: FC<any> = ({
+  lng,
+  lngDict,
+  brand,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const router = useRouter()
+  const i18n: any = useI18n()
+  const size = useWindowSize()
+
+  const [pageInfo, setPageInfo] = useState({
+    pageNumber: 0,
+    itemPerPage: 6,
+    totalItems: 0,
+  })
+
+  const { currPage } = useInfiniteScroll(pageInfo, 'category_list:last-child')
+
+  const layoutProps = {
+    i18n,
+    lng,
+    lngDict,
+    brand,
+    headerTitle: i18n.t('categories.title'),
+    SEO: {
+      title: i18n.t("categories.title")
+    }
+  }
+
+  return (
+    <Layout {...layoutProps}>
+      <SEO title={i18n.t("product.products")} />
+      <div className="container mt-5 pt-4 pb-3">
+        <Breadcrumb
+          steps={[{ label: i18n.t('breadcrumb.home') }, { label: i18n.t('categories.categories') }]}
+        />
+      </div>
+      <div className={`container ${styleProducts.products}`}>
+        <div className="row">
+          {Array.from(Array(currPage + 1)).map((_, i) => (
+            <ProductListByCategory
+              key={i}
+              pageNumber={i}
+              productCategoryType="INFINITE_SCROLL"
+              itemPerPage={pageInfo.itemPerPage}
+              classes={classesProductCategory}
+              itemProductsPerCategory={3}
+              getPageInfo={setPageInfo as any}
+              thumborSetting={{
+                width: size.width < 768 ? 512 : 800,
+                format: "webp",
+                quality: 85,
+              }}
+              emptyStateComponent={
+                <div className="col-12 my-3">
+                  <EmptyComponent
+                    icon={<RiQuestionFill color="#A8A8A8" size={20} />}
+                    title={i18n.t("product.isEmpty")}
+                  />
+                </div>
+              }
+              loadingComponent={
+                <div className="col-12">
+                  <div className="d-flex justify-content-center align-center my-5">
+                    <Loader
+                      color="text-secondary"
+                      withText
+                    />
+                  </div>
+                </div>
+              }
+            />
+          ))}
+          {(pageInfo.totalItems === 0) &&
+            <div className="col-12">
+              <button
+                className={`${styleButton.btn} ${styleButton.btn_secondary}`}
+                onClick={() => router.push(`/${lng}/products`)}
+              >
+                {i18n.t("products.seeAllProduct")}
+              </button>
+            </div>
+          }
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({
+  req,
+  params,
+}) => {
+  const brand = await useBrand(req)
+  const defaultLanguage = brand?.settings?.defaultLanguage || params.lng || 'id'
+  const { default: lngDict = {} } = await import(`locales/${defaultLanguage}.json`)
+
+  return {
+    props: {
+      lng: defaultLanguage,
+      lngDict,
+      brand: brand || ""
+    }
+  }
+}
+
+export default CategoriesPage

--- a/pages/[lng]/categories/index.tsx
+++ b/pages/[lng]/categories/index.tsx
@@ -2,7 +2,7 @@
 import { FC, useState } from 'react'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { useRouter } from 'next/router'
-import { RiQuestionFill } from 'react-icons/ri'
+import { IoHelpCircle } from 'react-icons/io5'
 import { ProductListByCategory, useI18n } from '@sirclo/nexus'
 /* library template */
 import { useBrand } from 'lib/useBrand'
@@ -36,10 +36,10 @@ const classesProductCategory = {
   productPriceClassName: styleProduct.product_labelPrice,
   salePriceClassName: styleProduct.product_labelPrice__sale,
   priceClassName: styleProduct.product_labelPrice__price,
-  productsListCategoryHeaderTitleClassName: styles.productsListCategoryHeaderTitle,
-  productsListCategoryHeaderClassName: styles.productsListCategoryHeader,
-  productsListCategoryContainerClassName: styles.productsListCategoryContainer,
-  productsListCategoryHeaderLinkClassName: styles.productsListCategoryHeaderLink,
+  productsListCategoryHeaderTitleClassName: styles.productsListCategory_header_title,
+  productsListCategoryHeaderClassName: styles.productsListCategory_header,
+  productsListCategoryContainerClassName: styles.productsListCategory_container,
+  productsListCategoryHeaderLinkClassName: styles.productsListCategory_header_link,
   productsListContainerClassName: styles.productsListContainer,
 }
 
@@ -88,7 +88,7 @@ const CategoriesPage: FC<any> = ({
               productCategoryType="INFINITE_SCROLL"
               itemPerPage={pageInfo.itemPerPage}
               classes={classesProductCategory}
-              itemProductsPerCategory={3}
+              itemProductsPerCategory={6}
               getPageInfo={setPageInfo as any}
               thumborSetting={{
                 width: size.width < 768 ? 512 : 800,
@@ -98,7 +98,7 @@ const CategoriesPage: FC<any> = ({
               emptyStateComponent={
                 <div className="col-12 my-3">
                   <EmptyComponent
-                    icon={<RiQuestionFill color="#A8A8A8" size={20} />}
+                    icon={<IoHelpCircle color="#BCBCBC" size={20} />}
                     title={i18n.t("product.isEmpty")}
                   />
                 </div>

--- a/pages/[lng]/categories/index.tsx
+++ b/pages/[lng]/categories/index.tsx
@@ -88,7 +88,7 @@ const CategoriesPage: FC<any> = ({
               productCategoryType="INFINITE_SCROLL"
               itemPerPage={pageInfo.itemPerPage}
               classes={classesProductCategory}
-              itemProductsPerCategory={6}
+              itemProductsPerCategory={3}
               getPageInfo={setPageInfo as any}
               thumborSetting={{
                 width: size.width < 768 ? 512 : 800,

--- a/pages/[lng]/product/[slug].tsx
+++ b/pages/[lng]/product/[slug].tsx
@@ -68,6 +68,10 @@ const classesProductDetail = {
   descriptionClassName: styleProductDetail.productDetail_desc,
   additionalInfoClassName: 'd-none',
   accordionClassName: styleProductDetail.productDetail_descContainer,
+  // Stock Info
+  variantStockContainer: styleProductDetail.productDetail_stockContainer,
+  variantStockAvailableClassName: styleProductDetail.productDetail_variantAvailable,
+  variantOutOfStockClassName: styleProductDetail.productDetail_variantOutOfStock,
   // Open Order
   openOrderClassName: styleOpenOrder.openOrder,
   openOrderTitleClassName: styleOpenOrder.openOrder_title,
@@ -280,6 +284,7 @@ const Product: FC<any> = ({
           onError={() => setShowModalErrorAddToCart(true)}
           onErrorMsg={(msg) => msg && toast.error(msg)}
           withEstimateShipping={true}
+          withStockInfo
           prevIcon={<RiArrowLeftSLine color="#444444" size={25} />}
           nextIcon={<RiArrowRightSLine color="#444444" size={25} />}
           openOrderIconDate={

--- a/public/scss/components/ProductDetail.module.scss
+++ b/public/scss/components/ProductDetail.module.scss
@@ -390,6 +390,27 @@
     padding: 24px 0 0;
   }
 
+  &_stockContainer
+  {
+    @include flex(row, center, center);
+  }
+  
+  &_variantAvailable
+  {
+    @include typographyBuilder(secondary, 500, 10, 16);
+    color: $color_success;
+  }
+  
+  &_variantOutOfStock
+  {
+    @include typographyBuilder(secondary, 500, 12, 16);
+    color: $color_white;
+    text-transform: uppercase;
+    background: #898989;
+    padding: 4px 8px;
+    border-radius: 2px;
+  }
+
   &_empty
   {
     @include flex(row, center, center);

--- a/public/scss/components/ProductDetail.module.scss
+++ b/public/scss/components/ProductDetail.module.scss
@@ -396,28 +396,24 @@
     margin-bottom: 24px;
   }
   
-  &_variantAvailable::before
-  {
-    content: "";
-    display: block;
-    position: relative;
-    width: 10px;
-    height: 10px;
-    margin: 0 4px 0 0;
-    padding: 0;
-    border: none;
-    background-color: transparent;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-image: url("data:image/svg+xml,%3Csvg width='11' height='10' viewBox='0 0 11 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.49985 10.0005C2.73835 10.0005 0.499847 7.76199 0.499847 5.00049C0.499847 2.23899 2.73835 0.000488281 5.49985 0.000488281C8.26135 0.000488281 10.4998 2.23899 10.4998 5.00049C10.4998 7.76199 8.26135 10.0005 5.49985 10.0005ZM5.00135 7.00049L8.53635 3.46499L7.82935 2.75799L5.00135 5.58649L3.58685 4.17199L2.87985 4.87899L5.00135 7.00049Z' fill='%2353B671'/%3E%3C/svg%3E%0A");
-  }
-  
   &_variantAvailable
   {
     @include typographyBuilder(secondary, 500, 10, 16);
     @include flex(row, center, flex-start);
     color: $color_success;
     margin: 0;
+    @include svgIcon(true)
+    {
+      display: block;
+      position: relative;
+      width: 10px;
+      height: 10px;
+      margin: 0 4px 0 0;
+      padding: 0;
+      border: none;
+      background-color: transparent;
+      background-image: url("data:image/svg+xml,%3Csvg width='11' height='10' viewBox='0 0 11 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.49985 10.0005C2.73835 10.0005 0.499847 7.76199 0.499847 5.00049C0.499847 2.23899 2.73835 0.000488281 5.49985 0.000488281C8.26135 0.000488281 10.4998 2.23899 10.4998 5.00049C10.4998 7.76199 8.26135 10.0005 5.49985 10.0005ZM5.00135 7.00049L8.53635 3.46499L7.82935 2.75799L5.00135 5.58649L3.58685 4.17199L2.87985 4.87899L5.00135 7.00049Z' fill='%2353B671'/%3E%3C/svg%3E%0A");
+    }
   }
   
   &_variantOutOfStock
@@ -425,7 +421,7 @@
     @include typographyBuilder(secondary, 500, 12, 16);
     color: $color_white;
     text-transform: uppercase;
-    background: #898989;
+    background: $color_text_secondary;
     padding: 4px 8px;
     margin: 0;
     border-radius: 2px;

--- a/public/scss/components/ProductDetail.module.scss
+++ b/public/scss/components/ProductDetail.module.scss
@@ -393,6 +393,7 @@
   &_stockContainer
   {
     @include flex(row, center, center);
+    margin-bottom: 24px;
   }
   
   &_variantAvailable::before

--- a/public/scss/components/ProductDetail.module.scss
+++ b/public/scss/components/ProductDetail.module.scss
@@ -395,10 +395,28 @@
     @include flex(row, center, center);
   }
   
+  &_variantAvailable::before
+  {
+    content: "";
+    display: block;
+    position: relative;
+    width: 10px;
+    height: 10px;
+    margin: 0 4px 0 0;
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-image: url("data:image/svg+xml,%3Csvg width='11' height='10' viewBox='0 0 11 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.49985 10.0005C2.73835 10.0005 0.499847 7.76199 0.499847 5.00049C0.499847 2.23899 2.73835 0.000488281 5.49985 0.000488281C8.26135 0.000488281 10.4998 2.23899 10.4998 5.00049C10.4998 7.76199 8.26135 10.0005 5.49985 10.0005ZM5.00135 7.00049L8.53635 3.46499L7.82935 2.75799L5.00135 5.58649L3.58685 4.17199L2.87985 4.87899L5.00135 7.00049Z' fill='%2353B671'/%3E%3C/svg%3E%0A");
+  }
+  
   &_variantAvailable
   {
     @include typographyBuilder(secondary, 500, 10, 16);
+    @include flex(row, center, flex-start);
     color: $color_success;
+    margin: 0;
   }
   
   &_variantOutOfStock
@@ -408,9 +426,10 @@
     text-transform: uppercase;
     background: #898989;
     padding: 4px 8px;
+    margin: 0;
     border-radius: 2px;
   }
-
+  
   &_empty
   {
     @include flex(row, center, center);

--- a/public/scss/pages/Categories.module.scss
+++ b/public/scss/pages/Categories.module.scss
@@ -1,0 +1,23 @@
+@import '../utils/variables';
+
+.productsListCategoryHeaderTitle
+{
+  @include typographyBuilder(secondary, 500, 14, 24);
+  text-transform: capitalize;
+  color: $color_text_primary;
+  padding: 0 15px;
+}
+
+.productsListCategoryContainer
+{
+  max-width: stretch;
+}
+
+.productsListContainer
+{
+  @include flex(row, flex-start, flex-start);
+  @include fixedWidth(100%, false);
+  max-width: 375px;
+  flex-wrap: nowrap;
+  overflow: auto;
+}

--- a/public/scss/pages/Categories.module.scss
+++ b/public/scss/pages/Categories.module.scss
@@ -1,35 +1,38 @@
 @import '../utils/variables';
 
-.productsListCategoryHeader
+.productsListCategory
 {
-  @include flex(row, baseline, space-between);
-}
-
-.productsListCategoryHeaderTitle
-{
-  @include typographyBuilder(secondary, 500, 14, 24);
-  text-transform: capitalize;
-  color: $color_text_primary;
-  padding: 0 15px;
-}
-
-.productsListCategoryContainer
-{
-  max-width: stretch;
-  margin-bottom: 32px;
-}
-
-.productsListCategoryHeaderLink
-{
-  @include typographyBuilder(secondary, 500, 14, 24);
-  text-transform: capitalize;
-  color: $color_rose;
-  padding: 0 15px;
-
-  &:hover
+  &_container
   {
-    color: $color_rose;
-    text-decoration: none;
+    max-width: stretch;
+    margin-bottom: 32px;    
+  }
+
+  &_header
+  {
+    @include flex(row, baseline, space-between);
+
+    &_link
+    {
+      @include typographyBuilder(secondary, 500, 14, 24);
+      text-transform: capitalize;
+      color: $color_rose;
+      padding: 0 15px;
+
+      &:hover
+      {
+        color: $color_rose;
+        text-decoration: none;
+      }
+    }
+
+    &_title
+    {
+      @include typographyBuilder(secondary, 500, 14, 24);
+      text-transform: capitalize;
+      color: $color_text_primary;
+      padding: 0 15px;
+    }
   }
 }
 

--- a/public/scss/pages/Categories.module.scss
+++ b/public/scss/pages/Categories.module.scss
@@ -1,5 +1,10 @@
 @import '../utils/variables';
 
+.productsListCategoryHeader
+{
+  @include flex(row, baseline, space-between);
+}
+
 .productsListCategoryHeaderTitle
 {
   @include typographyBuilder(secondary, 500, 14, 24);
@@ -11,13 +16,39 @@
 .productsListCategoryContainer
 {
   max-width: stretch;
+  margin-bottom: 32px;
+}
+
+.productsListCategoryHeaderLink
+{
+  @include typographyBuilder(secondary, 500, 14, 24);
+  text-transform: capitalize;
+  color: $color_rose;
+  padding: 0 15px;
+
+  &:hover
+  {
+    color: $color_rose;
+    text-decoration: none;
+  }
+}
+
+.productsItemContainer
+{
+  max-width: 45%;
+  padding-right: 0;
+  
+  &Image
+  {
+    width: 100%;
+  }
 }
 
 .productsListContainer
 {
-  @include flex(row, flex-start, flex-start);
+  @include flex(row, flex-start, flex-start, false);
   @include fixedWidth(100%, false);
   max-width: 375px;
-  flex-wrap: nowrap;
   overflow: auto;
+  padding-right: 15px;
 }


### PR DESCRIPTION
```
This pull request includes:
- bump nexus version from 2.6.9 to 2.7.7
- add fill wa number locales
- add new page /categories
- add stock info on product detail page
```

Task: https://phabricator.sirclo.com/T33600

**Screenshots**
- Categories page
[Figma](https://www.figma.com/file/cl2GPB5tKKSNjA5CxPsJBB/%5BVENDOR%5D-Ros%C3%A9?node-id=2341%3A4540)
![mobile all categories updated](https://user-images.githubusercontent.com/55394860/175483133-509d7f10-e4c9-43aa-a1aa-6ab1c1fbde83.png)

- Available stock Product Detail page
[Figma](https://www.figma.com/file/cl2GPB5tKKSNjA5CxPsJBB/%5BVENDOR%5D-Ros%C3%A9?node-id=34%3A694)
![mobile available stock product detail](https://user-images.githubusercontent.com/55394860/175483043-9dc07585-94ff-44af-8e32-04ab3d5e1329.png)

- Empty stock Product Detail page
![mobile empty stock product detail](https://user-images.githubusercontent.com/55394860/175483248-72fb774c-c1e1-4a86-8d22-b6c895444dc8.png)

- Banner Category tidak di-implement karena belum disupport Nexus
![banner category not exported](https://user-images.githubusercontent.com/55394860/175483326-42ebf0a7-12d7-4bd5-b5a2-f0091c7ce553.png)
