### PR TITLE
fix: fix buyer note text overflowing

### DIFF
--- a/public/scss/components/CartDetail.module.scss
+++ b/public/scss/components/CartDetail.module.scss
@@ -311,6 +311,7 @@
       border: none;
       background-color: $color_rose_bg2;
       color: $color_text_primary;
+      word-break: break-all;
 
       &:empty
       {


### PR DESCRIPTION
URL PR: https://github.com/sirclo-solution/template-rose/pull/17
URL Task: https://phabricator.sirclo.com/T33595
Pull Latest: OK
Build (Local): OK

Perbaikan jika buyernote-nya kepanjangan bablas seperti pada gambar berikut:

![image](https://user-images.githubusercontent.com/1308515/176395868-31d079c9-5633-4456-a73d-cc1785e4c555.png)

Screenshot

![Screen Shot 2022-06-29 at 15 46 35](https://user-images.githubusercontent.com/1308515/176395671-28b88d2a-6495-408d-bbd7-83f7f5c08623.png)
