### PR TITLE
fix(voucher): add missing toast success copy

### DIFF
--- a/components/OrderSummaryBox/index.tsx
+++ b/components/OrderSummaryBox/index.tsx
@@ -224,6 +224,7 @@ const OrderSummaryComponent: FC<iProps> = ({
             }}
             submitButtonLabel={titleSubmit}
             continueShoppingLabel={i18n.t("orderSummary.continueShopping")}
+            onSuccessCopyCodeCoupon={() => toast.success(i18n.t('coupon.successCopyCode'))}
             onErrorMsg={(msg) => toast.error(msg)}
             onErrorMsgCoupon={(msg) => toast.error(msg)}
             isAccordion


### PR DESCRIPTION
**Place Order & Shipping Method**
--
popup voucher detail desktop
<img width="1001" alt="Screen Shot 2022-10-26 at 15 54 24" src="https://user-images.githubusercontent.com/43097333/197982505-926ac944-b337-430b-b627-322f7d229a97.png">

popup voucher detail mobile
![Tangkapan Layar 2022-10-26 pada 15 54 40](https://user-images.githubusercontent.com/43097333/197982608-4f5eb3b6-bc2d-4b81-9679-64619102fe1c.png)

**Additional Test**
--
Payment Method (sudah di PR sbelumnya)
<img width="1280" alt="Screen Shot 2022-10-26 at 16 07 57" src="https://user-images.githubusercontent.com/43097333/197985015-f35e27f7-1877-4356-82ca-130815a4e612.png">

<img width="381" alt="Screen Shot 2022-10-26 at 16 08 15" src="https://user-images.githubusercontent.com/43097333/197985068-823c697a-67ec-432b-8924-220ba9dde8e9.png">
