### PR TITLE
fix(payment-method): voucher code is not displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
-    "@types/lodash": "^4.14.187",
+    "@types/lodash": "4.14.182",
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
-    "@types/lodash": "^4.14.182",
+    "@types/lodash": "4.14.182",
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
-    "@types/lodash": "^4.14.155",
+    "@types/lodash": "^4.14.182",
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
-    "@types/lodash": "4.14.182",
+    "@types/lodash": "^4.14.155",
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
+    "@types/lodash": "^4.14.187",
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.1",
-    "@types/lodash": "^4.14.155",
     "@types/next": "^9.0.0",
     "@types/node": "^12.12.45",
     "@types/react": "17.0.39",

--- a/public/scss/components/OrderSummaryBox.module.scss
+++ b/public/scss/components/OrderSummaryBox.module.scss
@@ -747,6 +747,7 @@
 
     &_voucherDetailCode
     {
+        display: none;
         @include typographyBuilder(secondary, 400, 12, 16);
         position: relative;
         margin: 0;

--- a/public/scss/components/OrderSummaryBox.module.scss
+++ b/public/scss/components/OrderSummaryBox.module.scss
@@ -747,8 +747,8 @@
 
     &_voucherDetailCode
     {
-        display: none;
         @include typographyBuilder(secondary, 400, 12, 16);
+        display: none;
         position: relative;
         margin: 0;
         padding: 0;


### PR DESCRIPTION
```
- display none for voucher code
- update lodash lib to latest version to fix build error
```

before:
![image](https://user-images.githubusercontent.com/43097333/199157205-d0b2d772-88f3-44ea-ba65-09887c40f501.png)

after:

- Desktop
  <img width="1280" alt="Screen Shot 2022-11-01 at 11 10 12" src="https://user-images.githubusercontent.com/43097333/199157250-1d3cc167-0e56-42dc-ac25-9abcc27f3cfe.png">

- Mobile
    ![Screen Shot 2022-11-01 at 11 10 24](https://user-images.githubusercontent.com/43097333/199157261-b8a8aa99-c998-4c71-b4b2-c4712b3bd6f8.png)

- template is still running well with latest lodash lib version 
  <img width="611" alt="Screen Shot 2022-11-01 at 13 29 20" src="https://user-images.githubusercontent.com/43097333/199172777-3f0b5a43-95a1-4ff5-bec6-2f7a62df0e57.png">

