### PR TITLE
fix(footer): add copyright footer in legal page

### DIFF
--- a/pages/[lng]/legal/[slug].tsx
+++ b/pages/[lng]/legal/[slug].tsx
@@ -54,6 +54,7 @@ const LegalPage: FC<any> = ({
     brand,
     headerTitle: data?.title,
     layoutClassName: "layout_fullHeight",
+    withCopyright: true,
     SEO: { title: data?.title },
   }
 


### PR DESCRIPTION
Task : https://phabricator.sirclo.com/T43800

**Feedback QA : footer kepotong karena belum ada footer copyright**
![image (28)](https://user-images.githubusercontent.com/16263184/214024755-8305c7fe-05c1-4a60-8c0a-714e7e3025ea.png)

![Rose Theme - Kebijakan Privasi - Google Chrome 23_01_2023 17_57_20](https://user-images.githubusercontent.com/16263184/214024678-7abc02e2-388b-46ab-b261-484f0553efe2.png)


**After**
![Rose Theme - Kebijakan Privasi - Google Chrome 23_01_2023 17_57_33](https://user-images.githubusercontent.com/16263184/214024562-ab94c0ab-25f0-4684-b6dc-586683c267d8.png)
