### PR TITLE
chore: bump version nexus 2.19.9 to fix minus stock handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@brainhubeu/react-carousel": "^1.19.14",
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.5",
+    "@sirclo/nexus": "2.19.9",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
Proof of Work

Handling minus stock product
![image](https://github.com/sirclo-solution/template-rose/assets/45877085/098c6c6d-e0be-4233-8956-edbb5430dd10)
![image](https://github.com/sirclo-solution/template-rose/assets/45877085/df7ac3aa-47cb-4af8-9db0-5944b99f0548)

