### PR TITLE
chore: bump version nexus 2.19.9 to fix minus stock handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@brainhubeu/react-carousel": "^1.19.14",
     "@elgorditosalsero/react-gtm-hook": "^2.4.0",
-    "@sirclo/nexus": "2.19.5",
+    "@sirclo/nexus": "2.19.9",
     "bootstrap": "^4.5.0",
     "cookie": "^0.4.1",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
task: https://phabricator.sirclo.com/T50542